### PR TITLE
add google one tap sign-in backend protocol.

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+TtuckTak

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -21,5 +21,10 @@
       <option name="name" value="BintrayJCenter" />
       <option name="url" value="https://jcenter.bintray.com/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/TtuckTak.main.iml" filepath="$PROJECT_DIR$/.idea/modules/TtuckTak.main.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/modules/TtuckTak.main.iml
+++ b/.idea/modules/TtuckTak.main.iml
@@ -5,16 +5,4 @@
       <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
     </content>
   </component>
-  <component name="FacetManager">
-    <facet type="jpa" name="JPA">
-      <configuration>
-        <setting name="validation-enabled" value="true" />
-        <setting name="provider-name" value="Hibernate" />
-        <datasource-mapping>
-          <factory-entry name="entityManagerFactory" value="83b52d16-1cc9-4515-a4a4-7d2b1b01c2bd" />
-        </datasource-mapping>
-        <naming-strategy-map />
-      </configuration>
-    </facet>
-  </component>
 </module>

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    google()
 }
 
 dependencies {
@@ -70,6 +71,9 @@ dependencies {
 
     //Json
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+
+    //GoogleAPI
+    implementation 'com.google.api-client:google-api-client:1.33.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/service/ttucktak/base/BaseErrorCode.java
+++ b/src/main/java/com/service/ttucktak/base/BaseErrorCode.java
@@ -42,7 +42,9 @@ public enum BaseErrorCode {
     KAKAO_OAUTH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "카카오 로그인 중 오류발생 서버에 문의"),
     GOOGLE_OAUTH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "구글 로그인 중 오류발생 서버에 문의"),
     DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Database Error"),
-    UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예상치 못한 에러가 발생하였습니다.");
+    UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예상치 못한 에러가 발생하였습니다."),
+    GOOGLE_GENERALSECURITY_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR.value(), "구글 JWT 토큰 인증중 구글 시큐리티 문제가 발생하였습니다."),
+    GOOGLE_IOEXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR.value(), "구글 JWT 토큰 인증중 IO 문제가 발생하였습니다.");
     /**
      *
      * */

--- a/src/main/java/com/service/ttucktak/base/BaseErrorCode.java
+++ b/src/main/java/com/service/ttucktak/base/BaseErrorCode.java
@@ -24,6 +24,13 @@ public enum BaseErrorCode {
     INVALID_BIRTHDAY(HttpStatus.BAD_REQUEST.value(), "생일 형식에 맞지 않습니다 yyyy-MM-dd"),
     LOGIN_FAILED(HttpStatus.BAD_REQUEST.value(), "아이디나 비밀번호를 확인해주세요"),
 
+
+    /**
+     * 401 : UNATHORIZED
+     *
+     */
+    GOOGLE_OAUTH_EXPIRE(HttpStatus.UNAUTHORIZED.value(), "구글 로그인 중 오류발생 서버에 문의"),
+
     /**
      * 404 - NOT FOUND
      * */
@@ -33,6 +40,7 @@ public enum BaseErrorCode {
      * 500 INTERNAL SERVER ERROR
      * */
     KAKAO_OAUTH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "카카오 로그인 중 오류발생 서버에 문의"),
+    GOOGLE_OAUTH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "구글 로그인 중 오류발생 서버에 문의"),
     DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Database Error"),
     UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예상치 못한 에러가 발생하였습니다.");
     /**

--- a/src/main/java/com/service/ttucktak/config/security/CustomHttpHeaders.java
+++ b/src/main/java/com/service/ttucktak/config/security/CustomHttpHeaders.java
@@ -9,4 +9,6 @@ import org.springframework.http.HttpHeaders;
 public class CustomHttpHeaders extends HttpHeaders {
     public static final String REFRESH = "Refresh";
     public static final String KAKAO_AUTH = "Kakao-auth-code";
+
+    public static final String GOOGLE_ID = "Google-id-token";
 }

--- a/src/main/java/com/service/ttucktak/config/security/IgnoreSecurityConfig.java
+++ b/src/main/java/com/service/ttucktak/config/security/IgnoreSecurityConfig.java
@@ -35,6 +35,8 @@ public class IgnoreSecurityConfig {
                 .requestMatchers("/api/auths/login").permitAll()
                 .requestMatchers("/api/auths/oauth2/kakao").permitAll()
                 .requestMatchers("/api/auths/oauth2/login/kakao").permitAll()
+                .requestMatchers("/api/auths/oauth2/google").permitAll()
+                .requestMatchers("/api/auths/oauth2/login/google").permitAll()
                 .requestMatchers("/oauth2/authorization/kakao").permitAll()
                 .requestMatchers("/v3/api-docs/**").permitAll()
                 .requestMatchers("/swagger-ui/index.html").permitAll()

--- a/src/main/java/com/service/ttucktak/dto/auth/GoogleUserDto.java
+++ b/src/main/java/com/service/ttucktak/dto/auth/GoogleUserDto.java
@@ -1,0 +1,19 @@
+package com.service.ttucktak.dto.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Date;
+
+
+@Getter
+@Builder
+@ToString
+public class GoogleUserDto {
+    private final String userName;
+    private final String userEmail;
+    private final String imgURL;
+    private Date birthday;
+    private static int accountType;
+}

--- a/src/main/java/com/service/ttucktak/dto/auth/GoogleUserDto.java
+++ b/src/main/java/com/service/ttucktak/dto/auth/GoogleUserDto.java
@@ -8,7 +8,6 @@ import java.util.Date;
 
 
 @Getter
-@Builder
 @ToString
 public class GoogleUserDto {
     private final String userName;
@@ -16,4 +15,14 @@ public class GoogleUserDto {
     private final String imgURL;
     private Date birthday;
     private static int accountType;
+
+    @Builder
+    public GoogleUserDto (String userName,String userEmail,String imgURL, Date birthday){
+
+        this.userName = userName;
+        this.userEmail = userEmail;
+        this.imgURL = imgURL;
+        this.birthday = birthday;
+
+    }
 }

--- a/src/main/java/com/service/ttucktak/oAuth/OAuthService.java
+++ b/src/main/java/com/service/ttucktak/oAuth/OAuthService.java
@@ -1,9 +1,11 @@
 package com.service.ttucktak.oAuth;
 
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.service.ttucktak.base.BaseErrorCode;
 import com.service.ttucktak.base.BaseException;
+import com.service.ttucktak.dto.auth.GoogleUserDto;
 import com.service.ttucktak.dto.auth.KakaoUserDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -146,6 +148,36 @@ public class OAuthService {
         } catch (Exception exception){
             log.error("Exception in getKakaoUserInfo : " + exception.getMessage());
             throw new BaseException(BaseErrorCode.KAKAO_OAUTH_ERROR);
+        }
+    }
+
+    public GoogleUserDto getGoogleUserInfo(GoogleIdToken idToken) throws BaseException{
+        try{
+
+            GoogleIdToken.Payload payload = idToken.getPayload();
+
+            // Print user identifier
+            String userId = payload.getSubject();
+            System.out.println("User ID: " + userId);
+
+            // Get profile information from payload
+            String email = payload.getEmail();
+            boolean emailVerified = Boolean.valueOf(payload.getEmailVerified());
+            String name = (String) payload.get("name");
+            String pictureUrl = (String) payload.get("picture");
+
+            log.info("user info | name :" + name + " | email : " + email + " | imgURL : " + pictureUrl);
+
+            GoogleUserDto res = GoogleUserDto.builder().userName(name).userEmail(email).imgURL(pictureUrl).birthday(new Date()).build();
+
+            log.info(res.toString());
+
+            return res;
+            //구글 유저 정보 파싱 - end
+
+        } catch (Exception exception){
+            log.error("Exception in getGoogleUserInfo : " + exception.getMessage());
+            throw new BaseException(BaseErrorCode.GOOGLE_OAUTH_ERROR);
         }
     }
 }

--- a/src/main/java/com/service/ttucktak/utils/GoogleJwtUtil.java
+++ b/src/main/java/com/service/ttucktak/utils/GoogleJwtUtil.java
@@ -1,0 +1,43 @@
+package com.service.ttucktak.utils;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+
+@Component
+@Slf4j
+public class GoogleJwtUtil {
+
+    private static final String CLIENT_ID = "500809518937-2oeb6srpcf4u4p5mk3kk5e6rashj9qv0.apps.googleusercontent.com";
+
+    private GoogleIdTokenVerifier verifier;
+
+    public GoogleJwtUtil(){
+        verifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), new GsonFactory())
+                .setAudience(Collections.singletonList(CLIENT_ID))
+                .build();
+    }
+
+    public GoogleIdToken CheckGoogleIdTokenVerifier (String idTokenString){
+
+        GoogleIdToken idToken = null;
+        try {
+            idToken = verifier.verify(idTokenString);
+        } catch (GeneralSecurityException e) {
+            log.error("Google ID token verification GeneralSecurityException error",e);
+        } catch (IOException e) {
+            log.error("Google ID token verification IOException error",e);
+        }
+
+        return idToken;
+
+    }
+
+}

--- a/src/main/java/com/service/ttucktak/utils/GoogleJwtUtil.java
+++ b/src/main/java/com/service/ttucktak/utils/GoogleJwtUtil.java
@@ -4,8 +4,11 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
+import com.service.ttucktak.base.BaseErrorCode;
+import com.service.ttucktak.base.BaseException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -15,25 +18,26 @@ import java.util.Collections;
 @Slf4j
 public class GoogleJwtUtil {
 
-    private static final String CLIENT_ID = "500809518937-2oeb6srpcf4u4p5mk3kk5e6rashj9qv0.apps.googleusercontent.com";
+    private final GoogleIdTokenVerifier verifier;
 
-    private GoogleIdTokenVerifier verifier;
+    public GoogleJwtUtil(@Value("${jwt.client-id}") String CLIENT_ID){
 
-    public GoogleJwtUtil(){
         verifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), new GsonFactory())
                 .setAudience(Collections.singletonList(CLIENT_ID))
                 .build();
     }
 
-    public GoogleIdToken CheckGoogleIdTokenVerifier (String idTokenString){
+    public GoogleIdToken CheckGoogleIdTokenVerifier (String idTokenString) throws BaseException{
 
         GoogleIdToken idToken = null;
         try {
             idToken = verifier.verify(idTokenString);
         } catch (GeneralSecurityException e) {
-            log.error("Google ID token verification GeneralSecurityException error",e);
+            log.error("Google ID token verification GeneralSecurityException error (GoogleJwtUtil)",e);
+            throw new BaseException(BaseErrorCode.GOOGLE_GENERALSECURITY_EXCEPTION);
         } catch (IOException e) {
-            log.error("Google ID token verification IOException error",e);
+            log.error("Google ID token verification IOException error (GoogleJwtUtil)",e);
+            throw new BaseException(BaseErrorCode.GOOGLE_IOEXCEPTION);
         }
 
         return idToken;


### PR DESCRIPTION
구글 원탭 sign-in 방식을 활용한 사용자 로그인 절차 구현.

문제 : 

> 정확히 판단은 불가하나 현 구조상에서 생년월일 정보를 획득할 방법이 없음 -> 우선 생성시각으로 대체.

> 구글 ID 토큰처리에 있어서 만료 또는 에러시 처리 구조가 난감. -> 프론트 쪽 에러 처리 문제 가중 -> 개선 해볼만큼 해볼 예정.
