### PR TITLE
[FIX]: Swagger jwt header(#46)

### DIFF
--- a/src/main/java/com/service/ttucktak/config/SpringDocsConfig.java
+++ b/src/main/java/com/service/ttucktak/config/SpringDocsConfig.java
@@ -1,8 +1,13 @@
 package com.service.ttucktak.config;
 
+import com.service.ttucktak.config.security.CustomHttpHeaders;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,6 +24,16 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SpringDocsConfig {
 
+    public OpenApiCustomizer securityBudiler() {
+        return OpenAPI -> OpenAPI.addSecurityItem(new SecurityRequirement().addList("Access Token"))
+                .getComponents()
+                .addSecuritySchemes("Access Token", new SecurityScheme()
+                        .name(CustomHttpHeaders.AUTHORIZATION)
+                        .type(SecurityScheme.Type.HTTP)
+                        .in(SecurityScheme.In.HEADER)
+                        .bearerFormat("JWT")
+                        .scheme("bearer"));
+    }
     @Bean
     public GroupedOpenApi openApi(){
         String[] paths = {"/api/**"};
@@ -26,6 +41,7 @@ public class SpringDocsConfig {
         return GroupedOpenApi.builder()
                 .group("뚝딱 서비스 API")
                 .pathsToMatch(paths)
+                .addOpenApiCustomizer(securityBudiler())
                 .build();
     }
 }

--- a/src/main/java/com/service/ttucktak/utils/GoogleJwtUtil.java
+++ b/src/main/java/com/service/ttucktak/utils/GoogleJwtUtil.java
@@ -7,6 +7,7 @@ import com.google.api.client.json.gson.GsonFactory;
 import com.service.ttucktak.base.BaseErrorCode;
 import com.service.ttucktak.base.BaseException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import org.springframework.beans.factory.annotation.Value;
 


### PR DESCRIPTION
1. 작업 근거
#46 
2. 작업 내용
스웨거에 Jwt 로그인 버튼을 우 상단에 추가하여 한번의 로그인으로 사용 가능하게 해둠
3. 특이 사항
다만 API 명세에 Autorization 헤더가 required로 붙어있는데 이것은 아무거나 문자 입력하고 보내도 같이 안가니까 참고헤서 프론트에서 테스트 해야할듯