### PR TITLE
[FEAT] #74 - 사용자 닉네임 및 프로필 사진 업데이트 API 이동 및 개선, 사용자 push 알림 상태 조회 API 추가

### DIFF
--- a/src/main/java/com/service/ttucktak/controller/MemberController.java
+++ b/src/main/java/com/service/ttucktak/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.service.ttucktak.base.BaseException;
 import com.service.ttucktak.base.BaseResponse;
 import com.service.ttucktak.config.security.CustomHttpHeaders;
 import com.service.ttucktak.dto.auth.PatchPasswordLostReq;
+import com.service.ttucktak.dto.auth.PostUserDataReqDto;
 import com.service.ttucktak.dto.member.*;
 import com.service.ttucktak.dto.auth.PostUserDataResDto;
 import com.service.ttucktak.dto.auth.PutPasswordUpdateDto;
@@ -13,7 +14,9 @@ import com.service.ttucktak.entity.annotation.Nickname;
 import com.service.ttucktak.service.MemberService;
 import com.service.ttucktak.utils.JwtUtil;
 import com.service.ttucktak.utils.RegexUtil;
+import com.service.ttucktak.utils.S3Util;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -22,11 +25,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import org.springframework.http.MediaType;
 import org.springframework.ui.Model;
 
 import org.springframework.validation.annotation.Validated;
 
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
@@ -45,12 +50,15 @@ public class MemberController {
 
     private final EmailService emailService;
 
+    private S3Util s3Util;
+
     @Autowired
-    public MemberController(JwtUtil jwtUtil, RegexUtil regexUtil, MemberService memberService, EmailService emailService){
+    public MemberController(JwtUtil jwtUtil, RegexUtil regexUtil, MemberService memberService, EmailService emailService,S3Util s3Util){
         this.jwtUtil = jwtUtil;
         this.regexUtil = regexUtil;
         this.memberService = memberService;
         this.emailService = emailService;
+        this.s3Util = s3Util;
     }
 
     /**
@@ -88,6 +96,56 @@ public class MemberController {
         } catch (BaseException exception) {
             return new BaseResponse<>(exception);
         }
+    }
+
+    @Operation(summary = "닉네임 및 프로필 변경 API", description = "유저 정보 업데이트 API(닉네임 및 프로필)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "400", description = "userIdx 값에 오류 발생",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "500", description = "예상치 못한 에러가 발생하였습니다.",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Database result NotFound",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Database Error",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "500", description = "멤버 데이터 처리중 예상치 못한 에러가 발생하였습니다.",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    //Multipart form data임을 보여주어야 해서 어노테이션에 속성 추가
+    @PatchMapping(value = "/updateprofile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public BaseResponse<PostUserDataResDto> updateUserdata(@RequestPart(value = "ReqDto") @Parameter(description = "Try It Out 클릭하시면 데이터가 나와요") PostUserDataReqDto reqDto,
+                                                           @RequestPart(value = "file", required = false) @Parameter(description = "프로필 이미지") MultipartFile file,
+                                                           @RequestHeader(CustomHttpHeaders.AUTHORIZATION) String jwt) throws BaseException{
+
+        if(file != null){
+
+            String userImgUrl;
+
+            try{
+
+                userImgUrl = s3Util.upload(file,"S3UserProfile_develop");
+
+            }catch (Exception exception){
+                log.error("S3 이미지 파일 저장중 문제 발생 : " + exception.getMessage());
+                throw new BaseException(BaseErrorCode.UNEXPECTED_ERROR);
+            }
+
+            reqDto.setImgUpdate(userImgUrl);
+
+            // 차후 이미지 DB 준비 마무리 되면 그때 추가 작업.
+        }
+
+        UUID memberIdx;
+
+        try{
+            memberIdx = UUID.fromString(reqDto.getMemberIdx());
+        }catch(Exception exception){
+            log.error("UUID 변환중 문제 발생 : " + exception.getMessage());
+            throw new BaseException(BaseErrorCode.UUID_ERROR);
+        }
+
+        return new BaseResponse<>(memberService.updateUserByUUID(memberIdx,reqDto));
+
     }
 
     /**

--- a/src/main/java/com/service/ttucktak/dto/member/UserNoticeDto.java
+++ b/src/main/java/com/service/ttucktak/dto/member/UserNoticeDto.java
@@ -1,0 +1,24 @@
+package com.service.ttucktak.dto.member;
+
+import com.service.ttucktak.base.AccountType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class UserNoticeDto {
+    @Schema(name = "push_approve", example = "true", requiredProperties = "true", description = "push 알림 동의")
+    private boolean pushStatus;
+    @Schema(name = "night_approve", example = "true", requiredProperties = "true", description = "야간 push 알림 동의")
+    private boolean nightPushStatus;
+
+    @Builder
+    public UserNoticeDto(boolean pushStatus,boolean nightPushStatus){
+        this.pushStatus = pushStatus;
+        this.nightPushStatus = nightPushStatus;
+    }
+}

--- a/src/main/java/com/service/ttucktak/entity/Member.java
+++ b/src/main/java/com/service/ttucktak/entity/Member.java
@@ -131,6 +131,10 @@ public class Member extends BaseEntity implements UserDetails {
         return pushApprove;
     }
 
+    public boolean isNightPushApprove() {
+        return nightApprove;
+    }
+
     /**
      * UserDetail 구현 메서드
      */

--- a/src/main/java/com/service/ttucktak/service/MemberService.java
+++ b/src/main/java/com/service/ttucktak/service/MemberService.java
@@ -90,6 +90,19 @@ public class MemberService {
         return user;
     }
 
+    public UserNoticeDto loadUserPushByUUID(UUID userIdx) throws BaseException {
+        Optional<Member> res = memberRepository.findByMemberIdx(userIdx);
+
+        Member currentUser = res.orElseThrow(() -> new BaseException(BaseErrorCode.DATABASE_NOTFOUND));
+
+        UserNoticeDto notice = UserNoticeDto.builder()
+                .pushStatus(currentUser.isPushApprove())
+                .nightPushStatus(currentUser.isNightPushApprove())
+                .build();
+
+        return notice;
+    }
+
     /**
      * Push 알람 설정 API - Service
      * */
@@ -131,6 +144,11 @@ public class MemberService {
     }
 
     public PostUserDataResDto updateUserByUUID(UUID memberIdx, PostUserDataReqDto dto) throws BaseException {
+
+        if(memberRepository.existsMemberByNickname(dto.getNickName())){
+            log.error("Member update중 닉네임 중복 발생 : " );
+            throw new BaseException(BaseErrorCode.ALREADY_EXIST_NICKNAME);
+        }
 
         Optional<Member> res = memberRepository.findByMemberIdx(memberIdx);
 


### PR DESCRIPTION
74번 이슈 및 87번 이슈 관련 작업 내용. 확인 요망.

기존 view API 내부 사용자 프로필 및 닉네임 업데이트 API Member로 이동 및 추가 개선.

사용자 push 상태 조회 API 추가 완료.