### PR TITLE
[FIX] #96 - 프로필 업데이트시 기존 닉네임 유지 불가능 현상 FIX

### DIFF
--- a/src/main/java/com/service/ttucktak/service/MemberService.java
+++ b/src/main/java/com/service/ttucktak/service/MemberService.java
@@ -145,14 +145,16 @@ public class MemberService {
 
     public PostUserDataResDto updateUserByUUID(UUID memberIdx, PostUserDataReqDto dto) throws BaseException {
 
-        if(memberRepository.existsMemberByNickname(dto.getNickName())){
-            log.error("Member update중 닉네임 중복 발생 : " );
-            throw new BaseException(BaseErrorCode.ALREADY_EXIST_NICKNAME);
-        }
-
         Optional<Member> res = memberRepository.findByMemberIdx(memberIdx);
 
         Member currentUser = res.orElseThrow(() -> new BaseException(BaseErrorCode.DATABASE_NOTFOUND));
+
+        if(!currentUser.getNickname().equals(dto.getNickName())){
+            if(memberRepository.existsMemberByNickname(dto.getNickName())){
+                log.error("Member update중 닉네임 중복 발생 : " );
+                throw new BaseException(BaseErrorCode.ALREADY_EXIST_NICKNAME);
+            }
+        }
 
         try{
             currentUser.updateUserProfile(dto);


### PR DESCRIPTION
quick FIX : IF 문 체킹 추가 : 차후 닉네임 중복 체크 함수자체 수정 